### PR TITLE
Add more key-based navigation options.

### DIFF
--- a/src/crates_io.rs
+++ b/src/crates_io.rs
@@ -39,7 +39,15 @@ impl std::fmt::Display for CratesSort {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CrateSearchResponse {
+    pub meta: CrateSearchResponseMeta,
     pub crates: Vec<CrateSearch>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CrateSearchResponseMeta {
+    pub total: usize,
+    pub next_page: Option<String>,
+    pub prev_page: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,12 +1,21 @@
 use std::{sync::mpsc::Sender, time::Duration};
 
-use crossterm::event::{self, Event as TermEvent, KeyCode};
+use crossterm::event::{self, Event as TermEvent, KeyCode, Event};
 
 pub enum InputEvent {
     Char(char),
     Esc,
     Enter,
     Backspace,
+    Right,
+    Left,
+    Resize,
+    Up,
+    Down,
+    PageUp,
+    PageDown,
+    Home,
+    End,
 }
 
 pub struct InputMonitor {
@@ -21,13 +30,26 @@ impl InputMonitor {
     pub fn monitor(&self) {
         loop {
             if let Ok(true) = event::poll(Duration::from_secs(10)) {
-                if let TermEvent::Key(key) = event::read().unwrap() {
-                    match key.code {
+                match event::read().unwrap() {
+                    Event::Key(key) => match key.code {
                         KeyCode::Esc => self.tx.send(InputEvent::Esc).unwrap(),
                         KeyCode::Enter => self.tx.send(InputEvent::Enter).unwrap(),
                         KeyCode::Backspace => self.tx.send(InputEvent::Backspace).unwrap(),
                         KeyCode::Char(c) => self.tx.send(InputEvent::Char(c)).unwrap(),
+                        KeyCode::Right => self.tx.send(InputEvent::Right).unwrap(),
+                        KeyCode::Left => self.tx.send(InputEvent::Left).unwrap(),
+                        KeyCode::Up => self.tx.send(InputEvent::Up).unwrap(),
+                        KeyCode::Down => self.tx.send(InputEvent::Down).unwrap(),
+                        KeyCode::PageUp => self.tx.send(InputEvent::PageUp).unwrap(),
+                        KeyCode::PageDown => self.tx.send(InputEvent::PageDown).unwrap(),
+                        KeyCode::Home => self.tx.send(InputEvent::Home).unwrap(),
+                        KeyCode::End => self.tx.send(InputEvent::End).unwrap(),
+
                         _ => {}
+                    }
+                    Event::Mouse(_) => {}
+                    Event::Resize(_, _) => {
+                        self.tx.send(InputEvent::Resize).unwrap();
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
     disable_raw_mode()?;
     execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
-
+    terminal.clear();
     Ok(())
 }


### PR DESCRIPTION
I'm used to being able to use arrow keys, page keys and Home / End to navigate through lists of items in various applications, and I thought it would be nice to have here as well.

This PR adds the following behaviour:

Up (and also k / K) navigates one item back - if we are at the first item and there is a previous page, we go to the last item on the previous page.

Down (and also j / J) navigates one item forwards - if we are at the last item and there is a next page, we go to the first item on the next page.

PageUp, Right (and also p / P) navigates one page backwards, if there is a previous page, and sets the selection to the first item.

PageDown, Left (and also n / N) navigates one page forwards, if there is a next page, and sets the selection to the first item.

Home navigates to the first page of results, and End navigates to the last page of results.

As a side note, I encounter frequent pauses while using the app - I think with the new page scrolling logic, fetching more items at once (eg. 50 or 100) should be possible so we don't have pauses between every page switch. Additionally, resizing the terminal seems to break the UI - I capture the ResizeEvent, but it's not clear why the terminal isn't redrawn correctly.

I think being able to customize default fields and settings would also be a nice feature - eg. you could choose number of pages to fetch, which keys are used for navigation, default sorting behaviour, and have the app use these settings at runtime.
