### PR TITLE
Cache searches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ clap = "2.3.3"
 default = ["clipboard"]
 
 no-copy = []
+

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,10 +8,9 @@ use tui::{
     Frame,
 };
 
-#[cfg(feature = "clipboard")]
+#[cfg(not(feature = "no-copy"))]
 use clipboard::{ClipboardContext, ClipboardProvider};
 
-#[cfg(feature = "clipboard")]
 use crate::crates_io::CrateSearch;
 
 use crate::{
@@ -360,7 +359,7 @@ impl App {
         self.selection = if crates.is_empty() { None } else { Some(0) }
     }
 
-    #[cfg(feature = "clipboard")]
+    #[cfg(not(feature = "no-copy"))]
     fn copy_selection(&self) {
         if let Some(selection) = self.selection {
             if let Some((_, crates)) = self.get_cached_crates() {
@@ -376,6 +375,6 @@ impl App {
         }
     }
 
-    #[cfg(not(feature = "clipboard"))]
+    #[cfg(feature = "no-copy")]
     fn copy_selection(&self) {}
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -236,7 +236,7 @@ impl App {
             }
         }
         if let Some((_, crates)) = self.get_cached_crates() {
-            self.selection = crates.len().checked_sub(1).map(|t| t as usize);
+            self.selection = crates.len().checked_sub(1);
         }
     }
 

--- a/src/crates_io.rs
+++ b/src/crates_io.rs
@@ -71,7 +71,7 @@ pub struct CrateSearch {
 }
 
 impl CrateSearch {
-    #[cfg(feature = "clipboard")]
+    #[cfg(not(feature = "no-copy"))]
     pub fn get_toml_str(&self) -> String {
         format!("{} = \"{}\"", self.id, self.newest_version)
     }

--- a/src/crates_io.rs
+++ b/src/crates_io.rs
@@ -244,7 +244,7 @@ impl CrateSearcher {
         items_per_page: u32,
         sort: &CratesSort,
     ) -> Result<CrateSearchResponse, reqwest::Error> {
-        self.search_sorted_count(term, page, 5, sort)
+        self.search_sorted_count(term, page, items_per_page, sort)
     }
 
     pub fn search_sorted_count<T: AsRef<str>>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,16 @@ mod crates_io;
 mod input;
 mod widgets;
 
+pub(crate) fn ceil_div(a: u32, b: u32) -> u32 {
+    if b == 0 {
+        panic!("attempt to divide by zero");
+    } else if a == 0 {
+        0
+    } else {
+        (a + b - 1) / b
+    }
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     let matches = parse_args();
     if matches.is_present("help") {

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -48,7 +48,7 @@ impl<'a> CrateWidget<'a> {
             self.crte.created_at.format(STR_FORMAT).to_string()
         );
         let paragraph = Paragraph::new(paragraph.as_str())
-            .style(style.clone())
+            .style(style)
             .alignment(Left);
         paragraph.render(parts[0], buf);
 
@@ -57,19 +57,19 @@ impl<'a> CrateWidget<'a> {
             self.crte.updated_at.format(STR_FORMAT).to_string()
         );
         let paragraph = Paragraph::new(paragraph.as_str())
-            .style(style.clone())
+            .style(style)
             .alignment(Center);
         paragraph.render(parts[1], buf);
 
         let paragraph = format!("Downloads: {}", self.crte.downloads);
         let paragraph = Paragraph::new(paragraph.as_str())
-            .style(style.clone())
+            .style(style)
             .alignment(Center);
         paragraph.render(parts[2], buf);
 
         let paragraph = format!("Recent Downloads: {}", self.crte.recent_downloads);
         let paragraph = Paragraph::new(paragraph.as_str())
-            .style(style.clone())
+            .style(style)
             .alignment(Right);
         paragraph.render(parts[3], buf);
     }


### PR DESCRIPTION
This adds caching for searches, and also increases the fetched page size to ten times the number of visible items. This reduces the number of API requests significantly (and doesn't really reduce performance, since the majority of time is spent waiting for IO). By extension, there is no more pausing when scrolling through previously fetched pages, and pauses are encountered less frequently when scrolling linearly (eg. 10x less). It would be nice to have this prefetched in a background thread (might require adding interior mutability via Arc<> and waiting until the page is released), which would make pauses very rare.

This also makes changing the number of items per page very easy, since this is now stored as a field in the App struct, and can be updated on the fly to accomodate events such as terminal resizing or user specified settings.

A few formatting fixes and clippy lints are also included.